### PR TITLE
Cancel if Device in Standby / Frost Setting

### DIFF
--- a/NeoConnect.UnitTests/SyntheticTests.cs
+++ b/NeoConnect.UnitTests/SyntheticTests.cs
@@ -23,7 +23,6 @@ namespace NeoConnect.UnitTests
 
             _config = new HeatingConfig
             {
-                SummerProfileName = "Summer",
                 PreHeatOverride = new PreHeatOverrideConfig
                 {
                     MaxPreheatHours = 4,                    
@@ -52,6 +51,7 @@ namespace NeoConnect.UnitTests
                 IsThermostat = true,
                 IsOffline = false,
                 ActiveProfile = 1,
+                SetTemp = "15"
             };
             _mockNeoHubService.Setup(s => s.GetDevices(It.IsAny<CancellationToken>())).ReturnsAsync(new List<NeoDevice>() { _device });
 
@@ -76,7 +76,7 @@ namespace NeoConnect.UnitTests
 
             var engineersData = new Dictionary<string, EngineersData>
             {
-                { "Lounge", new EngineersData { MaxPreheatDuration = -1 } }
+                { "Lounge", new EngineersData { MaxPreheatDuration = -1, FrostTemp = 12 } }
             };            
             _mockNeoHubService.Setup(s => s.GetEngineersData(It.IsAny<CancellationToken>())).ReturnsAsync(engineersData);            
             

--- a/NeoConnect/ActionsService.cs
+++ b/NeoConnect/ActionsService.cs
@@ -23,13 +23,13 @@ namespace NeoConnect
             {
                 var forecast = await _weatherService.GetForecast(stoppingToken);
 
-                await _heatingService.Init(stoppingToken);
-
-                _logger.LogInformation("Running Action: RunRecipeBasedOnWeatherConditions.");
-                await _heatingService.RunRecipeBasedOnWeatherConditions(forecast.ForecastDay[0], stoppingToken);
+                await _heatingService.Init(stoppingToken);                
 
                 _logger.LogInformation("Running Action: SetMaxPreheatDurationBasedOnWeatherConditions.");
                 await _heatingService.SetMaxPreheatDurationBasedOnWeatherConditions(forecast.ForecastDay[0], stoppingToken);
+
+                _logger.LogInformation("Running Action: RunRecipeBasedOnWeatherConditions.");
+                await _heatingService.RunRecipeBasedOnWeatherConditions(forecast.ForecastDay[0], stoppingToken);
 
                 var changes = _heatingService.GetChangesMade();
                 if (changes.Count == 0)

--- a/NeoConnect/HeatingConfig.cs
+++ b/NeoConnect/HeatingConfig.cs
@@ -1,9 +1,7 @@
 ﻿namespace NeoConnect
 {
     public class HeatingConfig
-    {
-        public string SummerProfileName { get; set; }
-        
+    {   
         public PreHeatOverrideConfig PreHeatOverride { get; set; } = new PreHeatOverrideConfig();      
         public RecipeConfig Recipes { get; set; } = new RecipeConfig();
     }

--- a/NeoConnect/NeoHubResponse.cs
+++ b/NeoConnect/NeoHubResponse.cs
@@ -37,7 +37,7 @@ namespace NeoConnect
         public string ActualTemp { get; set; }
 
         [JsonPropertyName("SET_TEMP")]
-        public string TargetTemp { get; set; }
+        public string SetTemp { get; set; }
 
         [JsonPropertyName("ZONE_NAME")]
         public string ZoneName { get; set; }
@@ -47,6 +47,9 @@ namespace NeoConnect
 
         [JsonPropertyName("OFFLINE")]
         public bool IsOffline { get; set; }
+
+        [JsonPropertyName("STANDBY")]
+        public bool IsStandby { get; set; }
     }
 
     public class Profile
@@ -94,7 +97,10 @@ namespace NeoConnect
         public int DeviceType { get; set; }
 
         [JsonPropertyName("MAX_PREHEAT")]
-        public int MaxPreheatDuration { get; set; }       
+        public int MaxPreheatDuration { get; set; }
+
+        [JsonPropertyName("FROST_TEMP")]
+        public int FrostTemp { get; set; }
     }
 }
 

--- a/NeoConnect/NeoHubService.cs
+++ b/NeoConnect/NeoHubService.cs
@@ -117,9 +117,6 @@ namespace NeoConnect
             await SendMessage("RUN_RECIPE", $"['{recipeName}']", 4, cancellationToken);
 
             await ReceiveMessage(cancellationToken);
-
-            // wait five seconds to allow time for recipe to complete before continuing.
-            await Task.Delay(5000, cancellationToken);
         }
 
         public async Task SetPreheatDuration(string zoneName, int maxPreheatDuration, CancellationToken cancellationToken)

--- a/NeoConnect/appsettings.json
+++ b/NeoConnect/appsettings.json
@@ -6,7 +6,6 @@
     }
   },
   "HeatingConfig": {
-    "SummerProfileName": "Summer Mode",
     "PreHeatOverride": {
       "Enabled": true,
       "MaxPreheatHours": 3,
@@ -14,6 +13,10 @@
         {
           "Temp": 4.0,
           "Weighting": 0.7
+        },
+        {
+          "Temp": 5.0,
+          "Weighting": 0.6
         },
         {
           "Temp": 6.0,
@@ -40,7 +43,7 @@
       ]
     },
     "Recipes": {
-      "Enabled": true,
+      "Enabled": false,
       "ExternalTempThreshold": 14,
       "SummerRecipeName": "Summer Mode",
       "WinterRecipeName": "Winter Mode"


### PR DESCRIPTION
Added logic to cancel MaxPreheat routine if device is in Standby mode. This replaces logic which checked the name of the profile applied to the device, which was use-case specific.
Also changed order of the two routines to that recipe runs second.